### PR TITLE
Feature #187 by bartvig: Don't set action-buttons-is-visible css class on action buttons

### DIFF
--- a/js/ding_bookmark.js
+++ b/js/ding_bookmark.js
@@ -70,7 +70,6 @@
 
         // Toggle buttons based on count.
         if (count > 0) {
-          btn.closest('.action-buttons').addClass('action-buttons-is-visible');
           if (!actions_offset) {
             // First time buttons are shown, get their offset value.
             actions_offset = actions.offset().top;
@@ -78,7 +77,6 @@
           btn.removeAttr("disabled");
         }
         else {
-          btn.closest('.action-buttons').removeClass('action-buttons-is-visible');
           btn.prop('disabled', 'disabled');
         }
       });
@@ -97,7 +95,7 @@
      * moves the out of flow to follow the top of the screen on scroll.
      */
     function toggle_scroll_buttons() {
-      if (actions_offset < win.scrollTop() && actions.hasClass('action-buttons-is-visible')) {
+      if (actions_offset < win.scrollTop()) {
         actions.addClass('action-buttons-is-scrolling');
       }
       else {


### PR DESCRIPTION
Don't set action-buttons-is-visible css class on action buttons. This makes the action buttons be visible all the time, even when they're disabled.

http://platform.dandigbib.org/issues/187
